### PR TITLE
Added Config Options

### DIFF
--- a/src/main/java/com/Apothic0n/Lure/core/api/CreatureSpawnParameters.java
+++ b/src/main/java/com/Apothic0n/Lure/core/api/CreatureSpawnParameters.java
@@ -1,9 +1,43 @@
 package com.Apothic0n.Lure.core.api;
 
+import com.google.gson.*;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.block.Block;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 public record CreatureSpawnParameters(EntityType entityType, List<Block> adjacentBlocks, int amountRequired) {
+    public static class Deserializer implements JsonDeserializer<CreatureSpawnParameters> {
+        @Override
+        public CreatureSpawnParameters deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+            JsonObject json = jsonElement.getAsJsonObject();
+            EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.get(ResourceLocation.tryParse(GsonHelper.getAsString(json, "entityType")));
+            List<Block> blocks = new ArrayList<>();
+            JsonArray blocksJson = GsonHelper.getAsJsonArray(json, "blocks");
+            for (int i = 0; i < blocksJson.size(); i++) {
+                blocks.add(BuiltInRegistries.BLOCK.get(ResourceLocation.tryParse(blocksJson.get(i).getAsString())));
+            }
+            return new CreatureSpawnParameters(entityType, blocks, GsonHelper.getAsInt(json, "amountRequired"));
+        }
+    }
+
+    public static class Serializer implements JsonSerializer<CreatureSpawnParameters> {
+        @Override
+        public JsonElement serialize(CreatureSpawnParameters creatureSpawnParameters, Type type, JsonSerializationContext jsonSerializationContext) {
+            JsonObject json = new JsonObject();
+            json.addProperty("entityType", BuiltInRegistries.ENTITY_TYPE.getKey(creatureSpawnParameters.entityType()).toString());
+            JsonArray blocksJson = new JsonArray();
+            for (Block block : creatureSpawnParameters.adjacentBlocks()) {
+                blocksJson.add(BuiltInRegistries.BLOCK.getKey(block).toString());
+            }
+            json.add("blocks", blocksJson);
+            json.addProperty("amountRequired", creatureSpawnParameters.amountRequired());
+            return json;
+        }
+    }
 }

--- a/src/main/java/com/Apothic0n/Lure/core/api/MonsterSpawnParameters.java
+++ b/src/main/java/com/Apothic0n/Lure/core/api/MonsterSpawnParameters.java
@@ -1,11 +1,58 @@
 package com.Apothic0n.Lure.core.api;
 
+import com.google.gson.*;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
+import net.minecraft.tags.TagLoader;
+import net.minecraft.tags.TagManager;
+import net.minecraft.util.GsonHelper;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 
 public record MonsterSpawnParameters(EntityType entityType, List<TagKey<Biome>> validBiomeTags, List<ResourceKey<Biome>> validBiomes) {
+    public static class Deserializer implements JsonDeserializer<MonsterSpawnParameters> {
+        @Override
+        public MonsterSpawnParameters deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+            JsonObject json = jsonElement.getAsJsonObject();
+            EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.get(ResourceLocation.tryParse(GsonHelper.getAsString(json, "entityType")));
+            List<TagKey<Biome>> validBiomeTags = new ArrayList<>();
+            JsonArray validBiomeTagsJson = GsonHelper.getAsJsonArray(json, "validBiomeTags");
+            for (int i = 0; i < validBiomeTagsJson.size(); i++) {
+                validBiomeTags.add(TagKey.create(Registries.BIOME, ResourceLocation.tryParse(validBiomeTagsJson.get(i).getAsString())));
+            }
+            List<ResourceKey<Biome>> validBiomes = new ArrayList<>();
+            JsonArray validBiomesJson = GsonHelper.getAsJsonArray(json, "validBiomes");
+            for (int i = 0; i < validBiomesJson.size(); i++) {
+                validBiomes.add(ResourceKey.create(Registries.BIOME, ResourceLocation.tryParse(validBiomesJson.get(i).getAsString())));
+            }
+            return new MonsterSpawnParameters(entityType, validBiomeTags, validBiomes);
+        }
+    }
+
+    public static class Serializer implements JsonSerializer<MonsterSpawnParameters> {
+        @Override
+        public JsonElement serialize(MonsterSpawnParameters monsterSpawnParameters, Type type, JsonSerializationContext jsonSerializationContext) {
+            JsonObject json = new JsonObject();
+            json.addProperty("entityType", BuiltInRegistries.ENTITY_TYPE.getKey(monsterSpawnParameters.entityType()).toString());
+            JsonArray validBiomeTagsJson = new JsonArray();
+            for (TagKey<?> tagKey : monsterSpawnParameters.validBiomeTags()) {
+                validBiomeTagsJson.add(tagKey.location().toString());
+            }
+            json.add("validBiomeTags", validBiomeTagsJson);
+            JsonArray validBiomesJson = new JsonArray();
+            for (ResourceKey<?> resourceKey : monsterSpawnParameters.validBiomes()) {
+                validBiomeTagsJson.add(resourceKey.location().toString());
+            }
+            json.add("validBiomes", validBiomesJson);
+            return json;
+        }
+    }
 }

--- a/src/main/java/com/Apothic0n/Lure/core/api/MonsterSpawnParameters.java
+++ b/src/main/java/com/Apothic0n/Lure/core/api/MonsterSpawnParameters.java
@@ -49,7 +49,7 @@ public record MonsterSpawnParameters(EntityType entityType, List<TagKey<Biome>> 
             json.add("validBiomeTags", validBiomeTagsJson);
             JsonArray validBiomesJson = new JsonArray();
             for (ResourceKey<?> resourceKey : monsterSpawnParameters.validBiomes()) {
-                validBiomeTagsJson.add(resourceKey.location().toString());
+                validBiomesJson.add(resourceKey.location().toString());
             }
             json.add("validBiomes", validBiomesJson);
             return json;

--- a/src/main/java/com/Apothic0n/Lure/core/config/ConfigHandler.java
+++ b/src/main/java/com/Apothic0n/Lure/core/config/ConfigHandler.java
@@ -1,0 +1,117 @@
+package com.Apothic0n.Lure.core.config;
+
+import com.Apothic0n.Lure.Lure;
+import com.Apothic0n.Lure.core.api.CreatureSpawnParameters;
+import com.Apothic0n.Lure.core.api.MonsterSpawnParameters;
+import com.google.gson.*;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.fml.loading.FMLPaths;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ConfigHandler {
+    static final Gson gson = new GsonBuilder().setPrettyPrinting()
+            .registerTypeAdapter(CreatureSpawnParameters.class, new CreatureSpawnParameters.Deserializer())
+            .registerTypeAdapter(CreatureSpawnParameters.class, new CreatureSpawnParameters.Serializer())
+            .registerTypeAdapter(MonsterSpawnParameters.class, new MonsterSpawnParameters.Deserializer())
+            .registerTypeAdapter(MonsterSpawnParameters.class, new MonsterSpawnParameters.Serializer())
+            .registerTypeAdapter(LureConfig.class, new Deserializer())
+            .registerTypeAdapter(LureConfig.class, new Serializer()).create();
+    private final static String configPath = FMLPaths.CONFIGDIR.get().toString() + "/";
+    private final static String configName = Lure.MODID + ".json";
+    private static LureConfig LURE_CONFIG;
+
+    public static LureConfig create() throws IOException {
+        File configFile = new File(configPath + configName);
+        if (!configFile.exists()) {
+            try (FileWriter fw = new FileWriter(configFile.getPath())) {
+                gson.toJson(new LureConfig(), fw);
+            }
+        }
+
+        LURE_CONFIG = load();
+        return LURE_CONFIG;
+    }
+
+    public static LureConfig load() throws FileNotFoundException {
+        BufferedReader bufferedReader = new BufferedReader(new FileReader(configPath + configName));
+        return gson.fromJson(bufferedReader, LureConfig.class);
+    }
+
+    public static LureConfig getConfig() {
+        if (LURE_CONFIG == null) {
+            try {
+                LURE_CONFIG = ConfigHandler.create();
+            } catch (IOException e) {
+                Lure.LOGGER.error("Config was unable to be created!", e);
+            }
+        }
+        return LURE_CONFIG;
+    }
+
+    public static class Deserializer implements JsonDeserializer<LureConfig> {
+        @Override
+        public LureConfig deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+            LureConfig config = new LureConfig();
+            config.creatures.clear();
+            config.monsters.clear();
+            JsonObject creatures = GsonHelper.getAsJsonObject(jsonElement.getAsJsonObject(), "creatures");
+            for (String key : creatures.keySet()) {
+                Block block = BuiltInRegistries.BLOCK.get(ResourceLocation.tryParse(key));
+                config.creatures.put(block, new ArrayList<>());
+                JsonArray array = GsonHelper.getAsJsonArray(creatures, key);
+                for (JsonElement element : array) {
+                    config.creatures.get(block).add(gson.fromJson(element, CreatureSpawnParameters.class));
+                }
+            }
+            JsonObject monsters = GsonHelper.getAsJsonObject(jsonElement.getAsJsonObject(), "monsters");
+            for (String key : monsters.keySet()) {
+                LureConfig.MoonPhase moonPhase = LureConfig.MoonPhase.valueOf(key);
+                config.monsters.put(moonPhase, new ArrayList<>());
+                JsonArray array = GsonHelper.getAsJsonArray(monsters, key);
+                for (JsonElement element : array) {
+                    config.monsters.get(moonPhase).add(gson.fromJson(element, MonsterSpawnParameters.class));
+                }
+            }
+            return config;
+        }
+    }
+
+    public static class Serializer implements JsonSerializer<LureConfig> {
+        @Override
+        public JsonElement serialize(LureConfig config, Type type, JsonSerializationContext jsonSerializationContext) {
+            JsonObject json = new JsonObject();
+            JsonObject creatures = new JsonObject();
+            for (Map.Entry<Block, List<CreatureSpawnParameters>> spawn : config.creatures.entrySet()) {
+                JsonArray array = new JsonArray();
+                for (CreatureSpawnParameters parameters : spawn.getValue()) {
+                    array.add(gson.toJsonTree(parameters));
+                }
+                creatures.add(BuiltInRegistries.BLOCK.getKey(spawn.getKey()).toString(), array);
+            }
+            json.add("creatures", creatures);
+            JsonObject monsters = new JsonObject();
+            for (Map.Entry<LureConfig.MoonPhase, List<MonsterSpawnParameters>> spawn : config.monsters.entrySet()) {
+                JsonArray array = new JsonArray();
+                for (MonsterSpawnParameters parameters : spawn.getValue()) {
+                    array.add(gson.toJsonTree(parameters));
+                }
+                monsters.add(spawn.getKey().toString(), array);
+            }
+            json.add("monsters", monsters);
+            return json;
+        }
+    }
+}

--- a/src/main/java/com/Apothic0n/Lure/core/config/LureConfig.java
+++ b/src/main/java/com/Apothic0n/Lure/core/config/LureConfig.java
@@ -1,0 +1,175 @@
+package com.Apothic0n.Lure.core.config;
+
+import com.Apothic0n.Lure.core.api.CreatureSpawnParameters;
+import com.Apothic0n.Lure.core.api.MonsterSpawnParameters;
+import net.minecraft.tags.BiomeTags;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LureConfig {
+    public Map<Block, List<CreatureSpawnParameters>> creatures = new HashMap<>(Map.of(
+            Blocks.MUD, List.of(
+                    new CreatureSpawnParameters(EntityType.PIG, List.of(Blocks.CARROTS), 1),
+                    new CreatureSpawnParameters(EntityType.FROG, List.of(Blocks.MANGROVE_ROOTS), 1)
+            ),
+            Blocks.GRASS_BLOCK, List.of(
+                    new CreatureSpawnParameters(EntityType.SHEEP, List.of(Blocks.WHEAT), 1),
+                    new CreatureSpawnParameters(EntityType.CHICKEN, List.of(Blocks.GRASS, Blocks.TALL_GRASS), 4),
+                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1),
+                    new CreatureSpawnParameters(EntityType.OCELOT, List.of(Blocks.JUNGLE_LEAVES), 2),
+                    new CreatureSpawnParameters(EntityType.HORSE, List.of(Blocks.HAY_BLOCK), 1)
+            ),
+            Blocks.MYCELIUM, List.of(
+                    new CreatureSpawnParameters(EntityType.MOOSHROOM, List.of(Blocks.WHEAT), 1)
+            ),
+            Blocks.PACKED_MUD, List.of(
+                    new CreatureSpawnParameters(EntityType.COW, List.of(Blocks.WHEAT), 1),
+                    new CreatureSpawnParameters(EntityType.DONKEY, List.of(Blocks.HAY_BLOCK), 1)
+            ),
+            Blocks.PODZOL, List.of(
+                    new CreatureSpawnParameters(EntityType.FOX, List.of(Blocks.SWEET_BERRY_BUSH), 1),
+                    new CreatureSpawnParameters(EntityType.PANDA, List.of(Blocks.BAMBOO), 1),
+                    new CreatureSpawnParameters(EntityType.WOLF, List.of(Blocks.FERN), 1)
+            ),
+            Blocks.SNOW_BLOCK, List.of(
+                    new CreatureSpawnParameters(EntityType.POLAR_BEAR, List.of(Blocks.AIR), 4),
+                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1)
+            ),
+            Blocks.ICE, List.of(
+                    new CreatureSpawnParameters(EntityType.POLAR_BEAR, List.of(Blocks.AIR), 4)
+            ),
+            Blocks.SAND, List.of(
+                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1),
+                    new CreatureSpawnParameters(EntityType.TURTLE, List.of(Blocks.SEAGRASS), 1)
+            ),
+            Blocks.JUNGLE_LEAVES, List.of(
+                    new CreatureSpawnParameters(EntityType.PARROT, List.of(Blocks.AIR), 4)
+            ),
+            Blocks.STONE, List.of(
+                    new CreatureSpawnParameters(EntityType.GOAT, List.of(Blocks.WHEAT), 1)
+            )
+    ));
+
+    public Map<MoonPhase, List<MonsterSpawnParameters>> monsters = new HashMap<>(Map.of(
+            MoonPhase.full_moon, List.of( //Full Moon
+                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
+                    new MonsterSpawnParameters(EntityType.SPIDER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(BiomeTags.IS_OVERWORLD), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.STRAY, List.of(), List.of(Biomes.SNOWY_PLAINS, Biomes.ICE_SPIKES, Biomes.FROZEN_RIVER)),
+                    new MonsterSpawnParameters(EntityType.CREEPER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_OVERWORLD, BiomeTags.IS_NETHER, BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.WITCH, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.waning_gibbous, List.of(
+                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.last_quarter, List.of(
+                    new MonsterSpawnParameters(EntityType.SPIDER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.waning_crescent, List.of(
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(BiomeTags.IS_OVERWORLD), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.STRAY, List.of(), List.of(Biomes.SNOWY_PLAINS, Biomes.ICE_SPIKES, Biomes.FROZEN_RIVER)),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.new_moon, List.of(
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.CREEPER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.waxing_crescent, List.of(
+                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.first_quarter, List.of(
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_OVERWORLD, BiomeTags.IS_NETHER, BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            ),
+            MoonPhase.waxing_gibbous, List.of(
+                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
+                    new MonsterSpawnParameters(EntityType.WITCH, List.of(BiomeTags.IS_OVERWORLD), List.of()),
+                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
+                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
+                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
+                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
+            )
+    ));
+
+    public List<EntityType<?>> getAffectedCreatures() {
+        List<EntityType<?>> types = new ArrayList<>();
+        for (List<CreatureSpawnParameters> spawns : creatures.values()) {
+            for (CreatureSpawnParameters parameters : spawns) {
+                if (!types.contains(parameters.entityType())) types.add(parameters.entityType());
+            }
+        }
+        return types;
+    }
+
+    public enum MoonPhase {
+        full_moon,
+        waning_gibbous,
+        last_quarter,
+        waning_crescent,
+        new_moon,
+        waxing_crescent,
+        first_quarter,
+        waxing_gibbous
+    }
+}

--- a/src/main/java/com/Apothic0n/Lure/core/events/CommonForgeEvents.java
+++ b/src/main/java/com/Apothic0n/Lure/core/events/CommonForgeEvents.java
@@ -4,11 +4,12 @@ import com.Apothic0n.Lure.Lure;
 import com.Apothic0n.Lure.core.LureSavedData;
 import com.Apothic0n.Lure.core.api.CreatureSpawnParameters;
 import com.Apothic0n.Lure.core.api.MonsterSpawnParameters;
+import com.Apothic0n.Lure.core.config.ConfigHandler;
+import com.Apothic0n.Lure.core.config.LureConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.tags.BiomeTags;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobSpawnType;
 import net.minecraft.world.entity.player.Player;
@@ -29,159 +30,9 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
 import java.util.List;
-import java.util.Map;
 
 @Mod.EventBusSubscriber(modid = Lure.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class CommonForgeEvents {
-    public static List<EntityType> affectedMobs = List.of(
-            EntityType.PIG, EntityType.FROG, EntityType.SHEEP, EntityType.CHICKEN, EntityType.RABBIT, EntityType.OCELOT, EntityType.HORSE,
-            EntityType.MOOSHROOM, EntityType.COW, EntityType.DONKEY, EntityType.FOX, EntityType.PANDA, EntityType.WOLF, EntityType.POLAR_BEAR,
-            EntityType.PARROT, EntityType.GOAT, EntityType.TURTLE,
-
-            EntityType.ZOMBIE, EntityType.ZOMBIE_VILLAGER, EntityType.DROWNED, EntityType.HUSK, EntityType.SPIDER, EntityType.SKELETON,
-            EntityType.STRAY, EntityType.CREEPER, EntityType.ENDERMAN, EntityType.WITCH, EntityType.ZOMBIFIED_PIGLIN, EntityType.PIGLIN,
-            EntityType.HOGLIN, EntityType.GHAST, EntityType.SLIME
-    );
-
-    static List<Map<Block, List<CreatureSpawnParameters>>> creatures = List.of(
-            Map.of(Blocks.MUD, List.of(
-                    new CreatureSpawnParameters(EntityType.PIG, List.of(Blocks.CARROTS), 1),
-                    new CreatureSpawnParameters(EntityType.FROG, List.of(Blocks.MANGROVE_ROOTS), 1)
-            )),
-            Map.of(Blocks.GRASS_BLOCK, List.of(
-                    new CreatureSpawnParameters(EntityType.SHEEP, List.of(Blocks.WHEAT), 1),
-                    new CreatureSpawnParameters(EntityType.CHICKEN, List.of(Blocks.GRASS, Blocks.TALL_GRASS), 4),
-                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1),
-                    new CreatureSpawnParameters(EntityType.OCELOT, List.of(Blocks.JUNGLE_LEAVES), 2),
-                    new CreatureSpawnParameters(EntityType.HORSE, List.of(Blocks.HAY_BLOCK), 1)
-            )),
-            Map.of(Blocks.MYCELIUM, List.of(
-                    new CreatureSpawnParameters(EntityType.MOOSHROOM, List.of(Blocks.WHEAT), 1)
-            )),
-            Map.of(Blocks.PACKED_MUD, List.of(
-                    new CreatureSpawnParameters(EntityType.COW, List.of(Blocks.WHEAT), 1),
-                    new CreatureSpawnParameters(EntityType.DONKEY, List.of(Blocks.HAY_BLOCK), 1)
-            )),
-            Map.of(Blocks.PODZOL, List.of(
-                    new CreatureSpawnParameters(EntityType.FOX, List.of(Blocks.SWEET_BERRY_BUSH), 1),
-                    new CreatureSpawnParameters(EntityType.PANDA, List.of(Blocks.BAMBOO), 1),
-                    new CreatureSpawnParameters(EntityType.WOLF, List.of(Blocks.FERN), 1)
-            )),
-            Map.of(Blocks.SNOW_BLOCK, List.of(
-                    new CreatureSpawnParameters(EntityType.POLAR_BEAR, List.of(Blocks.AIR), 4),
-                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1)
-            )),
-            Map.of(Blocks.ICE, List.of(
-                    new CreatureSpawnParameters(EntityType.POLAR_BEAR, List.of(Blocks.AIR), 4)
-            )),
-            Map.of(Blocks.SAND, List.of(
-                    new CreatureSpawnParameters(EntityType.RABBIT, List.of(Blocks.CARROTS), 1)
-            )),
-            Map.of(Blocks.JUNGLE_LEAVES, List.of(
-                    new CreatureSpawnParameters(EntityType.PARROT, List.of(Blocks.AIR), 4)
-            )),
-            Map.of(Blocks.STONE, List.of(
-                    new CreatureSpawnParameters(EntityType.GOAT, List.of(Blocks.WHEAT), 1)
-            )),
-            Map.of(Blocks.SAND, List.of(
-                    new CreatureSpawnParameters(EntityType.TURTLE, List.of(Blocks.SEAGRASS), 1)
-            ))
-    );
-    static List<List<MonsterSpawnParameters>> monsters = List.of(
-            List.of( //Full Moon
-                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
-                    new MonsterSpawnParameters(EntityType.SPIDER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(BiomeTags.IS_OVERWORLD), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.STRAY, List.of(), List.of(Biomes.SNOWY_PLAINS, Biomes.ICE_SPIKES, Biomes.FROZEN_RIVER)),
-                    new MonsterSpawnParameters(EntityType.CREEPER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_OVERWORLD, BiomeTags.IS_NETHER, BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.WITCH, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.SPIDER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(BiomeTags.IS_OVERWORLD), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.STRAY, List.of(), List.of(Biomes.SNOWY_PLAINS, Biomes.ICE_SPIKES, Biomes.FROZEN_RIVER)),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.CREEPER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.ZOMBIE, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIE_VILLAGER, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.DROWNED, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.HUSK, List.of(), List.of(Biomes.DESERT)),
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_OVERWORLD, BiomeTags.IS_NETHER, BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            ),
-            List.of(
-                    new MonsterSpawnParameters(EntityType.SKELETON, List.of(), List.of(Biomes.SOUL_SAND_VALLEY)),
-                    new MonsterSpawnParameters(EntityType.WITCH, List.of(BiomeTags.IS_OVERWORLD), List.of()),
-                    new MonsterSpawnParameters(EntityType.ENDERMAN, List.of(BiomeTags.IS_END), List.of()),
-                    new MonsterSpawnParameters(EntityType.ZOMBIFIED_PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.PIGLIN, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.HOGLIN, List.of(), List.of(Biomes.CRIMSON_FOREST)),
-                    new MonsterSpawnParameters(EntityType.GHAST, List.of(), List.of(Biomes.NETHER_WASTES, Biomes.SOUL_SAND_VALLEY, Biomes.BASALT_DELTAS)),
-                    new MonsterSpawnParameters(EntityType.SLIME, List.of(), List.of(Biomes.SWAMP))
-            )
-    );
-
     static int spawnTick = 20;
 
     @SubscribeEvent
@@ -219,16 +70,15 @@ public class CommonForgeEvents {
             );
             BlockState belowState = level.getBlockState(pos.below());
             if ((belowState.isSolid() || belowState.is(Blocks.LAVA)) && !belowState.is(Blocks.BEDROCK)) {
+                LureConfig config = ConfigHandler.getConfig();
+                if (config == null) return false;
                 boolean light = (level.getBrightness(LightLayer.BLOCK, pos) > 0 || (level.getBrightness(LightLayer.SKY, pos) > 0 && level.canSeeSky(pos) && level.isDay()));
                 ChunkPos chunkPos = level.getChunkAt(pos).getPos();
                 if (light == true && dimension.equals(Level.OVERWORLD) && !LureSavedData.contains((ServerLevel) level, chunkPos)) {//creatures
                     CreatureSpawnParameters creatureSpawnParameters = new CreatureSpawnParameters(EntityType.BAT, List.of(Blocks.STRUCTURE_BLOCK), 4);
-                    for (int i = 0; i < creatures.size(); i++) {
-                        List<CreatureSpawnParameters> potentialCreatures = creatures.get(i).get(belowState.getBlock());
-                        if (potentialCreatures != null) {
-                            i = creatures.size();
-                            creatureSpawnParameters = potentialCreatures.get((int) Math.round(Math.random() * (potentialCreatures.size()-1)));
-                        }
+                    if (config.creatures.containsKey(belowState.getBlock())) {
+                        List<CreatureSpawnParameters> potentialCreatures = config.creatures.get(belowState.getBlock());
+                        creatureSpawnParameters = potentialCreatures.get((int)Math.round(Math.random() * (potentialCreatures.size() - 1)));
                     }
                     if (!(!creatureSpawnParameters.entityType().equals(EntityType.TURTLE) && centerState.is(Blocks.WATER)) && matchingBlocks(creatureSpawnParameters.adjacentBlocks(), neighbors, creatureSpawnParameters.amountRequired()) >= creatureSpawnParameters.amountRequired()) {
                         LureSavedData.add((ServerLevel) level, chunkPos);
@@ -245,7 +95,7 @@ public class CommonForgeEvents {
                     }
                 }
                 if (light == false && !belowState.is(Blocks.LAVA)) {//monsters
-                    List<MonsterSpawnParameters> potentialMonsters = monsters.get(level.getMoonPhase());
+                    List<MonsterSpawnParameters> potentialMonsters = config.monsters.get(LureConfig.MoonPhase.values()[level.getMoonPhase()]);
                     int firstChoice = (int) Math.round(Math.random() * (potentialMonsters.size()-1));
                     MonsterSpawnParameters monsterSpawnParameters = potentialMonsters.get(firstChoice);
                     Holder<Biome> biome = level.getBiome(pos);

--- a/src/main/java/com/Apothic0n/Lure/mixin/NaturalSpawnerMixin.java
+++ b/src/main/java/com/Apothic0n/Lure/mixin/NaturalSpawnerMixin.java
@@ -1,5 +1,7 @@
 package com.Apothic0n.Lure.mixin;
 
+import com.Apothic0n.Lure.core.config.ConfigHandler;
+import com.Apothic0n.Lure.core.config.LureConfig;
 import com.Apothic0n.Lure.core.events.CommonForgeEvents;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
@@ -111,7 +113,8 @@ public abstract class NaturalSpawnerMixin {
                                 entity.moveTo(d0, (double)blockpos.getY(), d1, p_220454_.nextFloat() * 360.0F, 0.0F);
                                 if (entity instanceof Mob) {
                                     Mob mob = (Mob)entity;
-                                    if ((net.minecraftforge.event.ForgeEventFactory.checkSpawnPosition(mob, p_220451_, MobSpawnType.CHUNK_GENERATION)) && !CommonForgeEvents.affectedMobs.contains(entity.getType())) {
+                                    LureConfig config = ConfigHandler.getConfig();
+                                    if ((net.minecraftforge.event.ForgeEventFactory.checkSpawnPosition(mob, p_220451_, MobSpawnType.CHUNK_GENERATION)) && !(config != null && config.getAffectedCreatures().contains(mob.getType()))) {
                                         spawngroupdata = mob.finalizeSpawn(p_220451_, p_220451_.getCurrentDifficultyAt(mob.blockPosition()), MobSpawnType.CHUNK_GENERATION, spawngroupdata, (CompoundTag)null);
                                         p_220451_.addFreshEntityWithPassengers(mob);
                                         flag = true;
@@ -177,7 +180,8 @@ public abstract class NaturalSpawnerMixin {
 
                             if (isValidSpawnPostitionForType(p_47040_, p_47039_, structuremanager, chunkgenerator, mobspawnsettings$spawnerdata, blockpos$mutableblockpos, d2) && p_47043_.test(mobspawnsettings$spawnerdata.type, blockpos$mutableblockpos, p_47041_)) {
                                 Mob mob = getMobForSpawn(p_47040_, mobspawnsettings$spawnerdata.type);
-                                if (mob == null || CommonForgeEvents.affectedMobs.contains(mob.getType())) {
+                                LureConfig config = ConfigHandler.getConfig();
+                                if (mob == null || (config != null && config.getAffectedCreatures().contains(mob.getType()))) {
                                     return;
                                 }
 


### PR DESCRIPTION
After finding this mod and wanting to use it for a modpack, I realised it didn't have any configs, meaning all of the mob spawns were hardcoded. For a moment, I thought this meant I couldn't use the mod, and then I remembered "Oh wait! I'm a programmer!" Configs are all stored in the main config directory as `lure.json`, and although the formatting is a bit bad, it's still usable. I added serializers into each of the spawn parameter classes, so if you plan on future changes to those, then it should be easily accessible. There is also a master serializer in `ConfigHandler` because `Gson` didn't like using blocks as keys. I also changed the moon phase access to be an `enum` for sake of readability.